### PR TITLE
Update wait_until to only accept a new error message...

### DIFF
--- a/lib/test-helpers/wait/wait.rb
+++ b/lib/test-helpers/wait/wait.rb
@@ -13,12 +13,12 @@ module TestHelpers
     end
 
     class Configuration
-      attr_accessor :wait_timeout, :wait_interval, :default_error
+      attr_accessor :wait_timeout, :wait_interval, :error_message
 
       def initialize
         @wait_timeout = 5.0
         @wait_interval = 0.1
-        @default_error = TimeoutError.new('Timed out waiting for block')
+        @error_message = 'Timed out waiting for block'
       end
     end
 
@@ -44,7 +44,7 @@ module TestHelpers
       return unless block_given?
       timeout = Float(options[:timeout] || TestHelpers::Wait.configuration.wait_timeout)
       interval = Float(options[:interval] || TestHelpers::Wait.configuration.wait_interval)
-      error = options[:error] || TestHelpers::Wait.configuration.default_error
+      error_message = options[:error_message] || TestHelpers::Wait.configuration.default_error
       end_time = ::Time.now + timeout
       until ::Time.now > end_time
         begin
@@ -56,7 +56,7 @@ module TestHelpers
       end
       result = yield
       return result if result
-      raise error
+      raise TimeoutError.new(error_message)
     end
 
   end

--- a/lib/test-helpers/wait/wait.rb
+++ b/lib/test-helpers/wait/wait.rb
@@ -44,7 +44,7 @@ module TestHelpers
       return unless block_given?
       timeout = Float(options[:timeout] || TestHelpers::Wait.configuration.wait_timeout)
       interval = Float(options[:interval] || TestHelpers::Wait.configuration.wait_interval)
-      error_message = options[:error_message] || TestHelpers::Wait.configuration.default_error
+      error_message = options[:error_message] || TestHelpers::Wait.configuration.error_message
       end_time = ::Time.now + timeout
       until ::Time.now > end_time
         begin

--- a/spec/wait_spec.rb
+++ b/spec/wait_spec.rb
@@ -133,11 +133,11 @@ describe TestHelpers::Wait do
         dummy_class.poll_and_assert { expect(true).to be false }
       end
 
-      context 'when a custom error is passed in' do
-        let(:error) { ArgumentError.new('blah') }
+      context 'when a custom error message is passed in' do
         it 'should eventually raise the given error' do
-          statement = -> { dummy_class.wait_until(error: error) { true == false } }
-          expect { statement.call }.to raise_error(error)
+          error_message = 'blah'
+          statement = -> { dummy_class.wait_until(error_message: error_message) { true == false } }
+          expect { statement.call }.to raise_error(TimeoutError, error_message)
         end
       end
     end

--- a/test-helpers.gemspec
+++ b/test-helpers.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
   s.name = 'test-helpers'
-  s.version = '0.2.0'
+  s.version = '0.3.0'
   s.date = '2015-08-25'
   s.summary = "Test helpers!"
   s.description = "A collection of helpers."


### PR DESCRIPTION
...and not a new error.  Always throw timeout error.
